### PR TITLE
Support Perl 5.42

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,10 @@ jobs:
       matrix:
         perl:
           [
+            "5.42",
+            "5.40",
+            "5.38",
+            "5.36",
             "5.34",
             "5.32",
             "5.30",
@@ -23,12 +27,12 @@ jobs:
             "5.10"
           ]
         include:
-          - perl: 5.34
+          - perl: 5.42
             coverage: true
     name: Perl ${{ matrix.perl }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Perl
       uses: shogo82148/actions-setup-perl@v1


### PR DESCRIPTION
## Summary
- Add Perl 5.36, 5.38, 5.40, 5.42 to the test matrix
- Update coverage target from Perl 5.34 to 5.42
- Update actions/checkout from v2 to v4

## Test plan
- [ ] Verify GitHub Actions run successfully on all Perl versions including 5.42

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)